### PR TITLE
Feature get api doc

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -25,3 +25,17 @@ describe("/api/topics", () => {
       });
   });
 });
+
+describe("/api", () => {
+  test("GET: 200 responds with an object describing all available endpoints", () => {
+    return request(app)
+      .get("/api")
+      .expect(200)
+      .then((response) => {
+        const endpoints = response.body.endpoints;
+        expect(endpoints).toHaveProperty("GET /api");
+        expect(endpoints).toHaveProperty("GET /api/topics");
+        expect(endpoints).toHaveProperty("GET /api/articles");
+      });
+  });
+});

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -18,9 +18,14 @@ describe("/api/topics", () => {
       .then((response) => {
         const topicsArray = response.body.topics;
         expect(Array.isArray(topicsArray)).toBe(true);
+        // Ensuring topicsArray is not empty for handling false positive
+        expect(topicsArray.length).toBeGreaterThan(0);
         topicsArray.forEach((topic) => {
-          expect(topic).toHaveProperty("slug", expect.any(String));
-          expect(topic).toHaveProperty("description", expect.any(String));
+          // Use MatchObject instead toHaveProperty
+          expect(topic).toMatchObject({
+            slug: expect.any(String),
+            description: expect.any(String),
+          });
         });
       });
   });
@@ -33,9 +38,24 @@ describe("/api", () => {
       .expect(200)
       .then((response) => {
         const endpoints = response.body.endpoints;
-        expect(endpoints).toHaveProperty("GET /api");
-        expect(endpoints).toHaveProperty("GET /api/topics");
-        expect(endpoints).toHaveProperty("GET /api/articles");
+        // Check if the endpoints object contains all expected keys
+        expect(endpoints).toMatchObject({
+          "GET /api": expect.objectContaining({
+            description: expect.any(String),
+          }),
+          "GET /api/topics": expect.objectContaining({
+            description: expect.any(String),
+            queries: expect.any(Array),
+            exampleResponse: expect.any(Object),
+          }),
+          "GET /api/articles": expect.objectContaining({
+            description: expect.any(String),
+            queries: expect.any(Array),
+            exampleResponse: expect.any(Object),
+          }),
+        });
+        // Ensure there are keys in the endpoints object
+        expect(Object.keys(endpoints).length).toBeGreaterThan(0);
       });
   });
 });

--- a/app.js
+++ b/app.js
@@ -1,9 +1,16 @@
 const express = require("express");
 const { getTopics } = require("./controllers/topics.controllers");
+const { getApi } = require("./controllers/api.controllers");
 const app = express();
 
 app.use(express.json());
 
+app.get("/api", getApi);
+
 app.get("/api/topics", getTopics);
+
+app.use((err, req, res, next) => {
+  res.status(500).send({ msg: "Internal Server Error" });
+});
 
 module.exports = app;

--- a/controllers/api.controllers.js
+++ b/controllers/api.controllers.js
@@ -1,0 +1,14 @@
+const fs = require("fs").promises;
+
+const getApi = (req, res, next) => {
+  const filePath = `${__dirname}/../endpoints.json`;
+
+  fs.readFile(filePath, "utf-8")
+    .then((data) => {
+      const endpoints = JSON.parse(data);
+      res.status(200).send({ endpoints });
+    })
+    .catch(next);
+};
+
+module.exports = { getApi };

--- a/controllers/topics.controllers.js
+++ b/controllers/topics.controllers.js
@@ -5,11 +5,7 @@ const getTopics = (req, res, next) => {
     .then((topics) => {
       res.status(200).send({ topics });
     })
-    .catch((err) => {
-      if (err) {
-        res.status(500).send({ msg: "Internal Server Error" });
-      }
-    });
+    .catch(next);
 };
 
 module.exports = { getTopics };


### PR DESCRIPTION
This pull request will add a Documentation endpoint (GET/api) to serve a JSON file of all available endpoints. It will have an implementation of the API controller that read and serve the static enpoints.json file using fs.promises. Also it has an improved Error handling by the middleware passing it into app.js. Finally it has changes under requested on the TDD to ensure there is no false positives and to have better testing using toMatchObject instead toHaveProperty.