### PR TITLE
Feature count comments by article

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -402,3 +402,28 @@ describe("/api/articles", () => {
       });
   });
 });
+
+describe("/api/articles", () => {
+  test("GET: 200 responds with articles filtered by topic", () => {
+    return request(app)
+      .get("/api/articles?topic=mitch")
+      .expect(200)
+      .then((response) => {
+        const articles = response.body.articles;
+        expect(Array.isArray(articles)).toBe(true);
+        expect(articles.length).toBeGreaterThan(0);
+        articles.forEach((article) => {
+          expect(article.topic).toBe("mitch");
+        });
+      });
+  });
+
+  test("GET: 400 responds with an error message for an invalid topic query", () => {
+    return request(app)
+      .get("/api/articles?topic=notTopic")
+      .expect(400)
+      .then((response) => {
+        expect(response.body.msg).toBe("Invalid topic value");
+      });
+  });
+});

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -65,6 +65,8 @@ describe("/api/articles/:article_id", () => {
           votes: 100,
           article_img_url:
             "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          // Updated test case to ensure new feature count comments for :article_id endpoint
+          comments_count: expect.any(Number),
         });
       });
   });

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -18,8 +18,8 @@ const getArticleById = (req, res, next) => {
 };
 
 const getArticles = (req, res, next) => {
-  const { sort_by, order } = req.query;
-  fetchArticles(sort_by, order)
+  const { sort_by, order, topic } = req.query;
+  fetchArticles(sort_by, order, topic)
     .then((articles) => {
       res.status(200).send({ articles });
     })

--- a/endpoints.json
+++ b/endpoints.json
@@ -10,7 +10,7 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles.You can sort them by passing queries. Defaults to sorting by 'created_at' in descending order.",
+    "description": "serves an array of all articles.You can sort them by passing queries and filter by. Defaults to sorting by 'created_at' in descending order.",
     "queries": ["author", "topic", "sort_by", "order"],
     "exampleResponse": {
       "articles": [

--- a/endpoints.json
+++ b/endpoints.json
@@ -36,7 +36,8 @@
         "body": "Text from the article..",
         "created_at": "2024-08-27T17:41:13.341Z",
         "votes": 0,
-        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        "comments_count": 6
       }
     }
   },

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -2,7 +2,16 @@ const db = require("../db/connection");
 
 const fetchArticleById = (article_id) => {
   return db
-    .query(`SELECT * FROM articles WHERE article_id = $1`, [article_id])
+    .query(
+      `
+    SELECT articles.*, COUNT(comments.comment_id)::integer AS comments_count
+    FROM articles
+    LEFT JOIN comments ON comments.article_id = articles.article_id
+    WHERE articles.article_id = $1
+    GROUP BY articles.article_id
+  `,
+      [article_id]
+    )
     .then(({ rows }) => {
       if (rows.length === 0) {
         return Promise.reject({


### PR DESCRIPTION
This pull request implements: 

-Added new feature to endpoint /api/articles/:article_id where it counts the comments of related Id
-Modified model to ensure the query now counts the comments as an integer
-Updated TDD to ensure that the response now has the new property on that endpoint
-Updated the endpoints.json file to have the new property added